### PR TITLE
Rename docker service

### DIFF
--- a/dighosp-docs/compose.yml
+++ b/dighosp-docs/compose.yml
@@ -1,7 +1,7 @@
 # Docker compose file for the "docs" subproject
 
 services:
-  web:
+  docs:
     build:
       context: .
       dockerfile: ./Dockerfile


### PR DESCRIPTION
Renaming this service reduces confusion when Docker Compose files are merged using the "include" directive in the master Compose file.